### PR TITLE
`class Regexp` の出力表現が曖昧な部分などの修正

### DIFF
--- a/refm/api/src/_builtin/Regexp
+++ b/refm/api/src/_builtin/Regexp
@@ -10,8 +10,8 @@ Regexp.new(string) を使って正規表現オブジェクトを動的に生成�
 
   str = "this is regexp"
   rp1 = Regexp.new("^this is regexp")
-  p rp1 =~ str           #=> 0
-  p Regexp.last_match[0] #=> "this is regexp"
+  p rp1 =~ str           # => 0
+  p Regexp.last_match[0] # => "this is regexp"
 
 [[d:spec/regexp]] や [[ref:d:spec/literal#regexp]] も参照してください。
 
@@ -41,7 +41,7 @@ Regexp.new(string) を使って正規表現オブジェクトを動的に生成�
   str = "This is Regexp"
   t1 = Regexp.compile("this is regexp", Regexp::IGNORECASE)
   t1.match(str)
-  puts $~ #=> This is Regexp 
+  p $~ # => "This is Regexp"
 
   t2 = Regexp.compile('
 	this         # ここは使用されない
@@ -49,12 +49,11 @@ Regexp.new(string) を使って正規表現オブジェクトを動的に生成�
 	\ regexp     # ここも使用されない
   ', Regexp::EXTENDED | Regexp::IGNORECASE)
   t2.match(str)
-  puts Regexp.last_match #=> This is Regexp
+  p Regexp.last_match # => "This is Regexp"
 
   str = "ふるいけや\nかわずとびこむ\nみずのおと"
   t2 = Regexp.compile("ふる.*?と", Regexp::MULTILINE)
-  puts t2.match(str)[0]  #=> ふるいけや
-                         #=> かわずと
+  p t2.match(str)[0]  # => "ふるいけや\nかわずと"
 
 --- escape(string) -> String
 --- quote(string) -> String
@@ -65,7 +64,7 @@ string の中で正規表現において特別な意味を持つ文字の直前�
 @param string 正規表現において特別な意味をもつ文字をもつ文字列を指定します。
 
   rp = Regexp.escape("$bc^")
-  puts rp #=> \$bc\^
+  p rp # => "\$bc\^"
 
 --- last_match -> MatchData
 
@@ -102,13 +101,13 @@ last_match[1] の形式では例外 [[c:NoMethodError]] が発生します。
 
   str = "This is Regexp"
   /That is Regexp/ =~ str
-  p Regexp.last_match #=> nil
+  p Regexp.last_match # => nil
   begin
     p Regexp.last_match[1] # 例外が発生する
   rescue 
-    puts $! #=> undefined method `[]' for nil:NilClass
+    puts $! # => undefined method `[]' for nil:NilClass
   end
-  p Regexp.last_match(1) #=> nil
+  p Regexp.last_match(1) # => nil
 
 @param nth 整数を指定します。
 	整数 nth が 0 の場合、マッチした文字列を返します。それ以外では、nth 番目の括弧にマッチした部分文字列を返します。
@@ -118,15 +117,15 @@ last_match[1] の形式では例外 [[c:NoMethodError]] が発生します。
 引数として与えた pattern を選択 | で連結し、Regexp として返します。
 結果の Regexp は与えた pattern のどれかにマッチする場合にマッチするものになります。
 
-  p Regexp.union(/a/, /b/, /c/) #=> /(?-mix:a)|(?-mix:b)|(?-mix:c)/
+  p Regexp.union(/a/, /b/, /c/) # => /(?-mix:a)|(?-mix:b)|(?-mix:c)/
 
 引数を一つだけ与える場合は、[[c:Array]] を与えても Regexp を生成します。
 つまり、以下のように書くことができます。
 
   arr = [/a/, /b/, /c/]
-  p Regexp.union(arr)  #=> /(?-mix:a)|(?-mix:b)|(?-mix:c)/
+  p Regexp.union(arr)  # => /(?-mix:a)|(?-mix:b)|(?-mix:c)/
   # 1.8.7 より前は、以下のように書く必要があった
-  p Regexp.union(*arr) #=> /(?-mix:a)|(?-mix:b)|(?-mix:c)/
+  p Regexp.union(*arr) # => /(?-mix:a)|(?-mix:b)|(?-mix:c)/
 
 pattern は Regexp または String で与えます。
 String で与えた場合、それ自身と等しい文字列にマッチするものと解釈され、
@@ -158,17 +157,17 @@ String で与えた場合、それ自身と等しい文字列にマッチする�
 
 
   # オプションは合成されない
-  p Regexp.union(/foo/i, /bar/x, /hoge/m) #=> /(?i-mx:foo)|(?x-mi:bar)|(?m-ix:hoge)/
+  p Regexp.union(/foo/i, /bar/x, /hoge/m) # => /(?i-mx:foo)|(?x-mi:bar)|(?m-ix:hoge)/
 
   # 文字列そのものにマッチする
   rep1 = [ "foo", "bar", "hoge"] 
-  p Regexp.union(*rep1) #=> /foo|bar|hoge/
-  p Regexp.union(rep1)  #=> /foo|bar|hoge/
+  p Regexp.union(*rep1) # => /foo|bar|hoge/
+  p Regexp.union(rep1)  # => /foo|bar|hoge/
 
   # 下記の場合オプションがつくのは最初だけ
   rep2 = [ /foo/x, "bar", "hoge"] 
-  p Regexp.union(*rep2) #=> /(?x-mi:foo)|bar|hoge/
-  p Regexp.union(rep2)  #=> /(?x-mi:foo)|bar|hoge/
+  p Regexp.union(*rep2) # => /(?x-mi:foo)|bar|hoge/
+  p Regexp.union(rep2)  # => /(?x-mi:foo)|bar|hoge/
 
 --- try_convert(obj) -> Regexp | nil
 
@@ -189,9 +188,9 @@ obj を to_regexp メソッドで Regexp オブジェクトに変換しようと
 場合、あるいは string が nil の場合には nil を返
 します。
 
-  p /foo/ =~ "foo"  #=> 0
-  p /foo/ =~ "afoo" #=> 1
-  p /foo/ =~ "bar"  #=> nil
+  p /foo/ =~ "foo"  # => 0
+  p /foo/ =~ "afoo" # => 1
+  p /foo/ =~ "bar"  # => nil
 
 組み込み変数 [[m:$~]] もしくは [[m:Regexp.last_match]] にマッチに関する情報 [[c:MatchData]] が設定されます。
 
@@ -202,21 +201,21 @@ obj を to_regexp メソッドで Regexp オブジェクトに変換しようと
 @raise TypeError string が nil でも [[c:String]] オブジェクト
                  でも [[c:Symbol]] でもない場合発生します。
 
-  p /foo/ =~ "foo"        #=> 0
-  p Regexp.last_match(0)  #=> "foo"
-  p /foo/ =~ "afoo"       #=> 1
-  p $~[0]                 #=> "foo"
-  p /foo/ =~ "bar"        #=> nil
+  p /foo/ =~ "foo"        # => 0
+  p Regexp.last_match(0)  # => "foo"
+  p /foo/ =~ "afoo"       # => 1
+  p $~[0]                 # => "foo"
+  p /foo/ =~ "bar"        # => nil
 
   unless /foo/ === "bar"
-    puts "not match " #=> not match
+    puts "not match " # => not match
   end
 
   str = []
   begin
     /ugo/ =~ str
   rescue TypeError
-    printf "! %s\t%s\n", $!, $@ #=> ! can't convert Array into String       r5.rb:15
+    printf "! %s\t%s\n", $!, $@ # => ! can't convert Array into String       r5.rb:15
   end
 
 --- ===(string) -> bool
@@ -232,11 +231,11 @@ string が文字列でもシンボルでもない場合には false を返しま
 例:
   a = "HELLO"
   case a
-  when /\A[a-z]*\z/; print "Lower case\n"
-  when /\A[A-Z]*\z/; print "Upper case\n"
-  else;            print "Mixed case\n"
+  when /\A[a-z]*\z/; puts "Lower case"
+  when /\A[A-Z]*\z/; puts "Upper case"
+  else;              puts "Mixed case"
   end
-  # => "Upper case"
+  # => Upper case
 
   /\A[a-z]*\z/ === "HELLO" # => false
   /\A[A-Z]*\z/ === "HELLO" # => true
@@ -259,7 +258,7 @@ string が文字列でもシンボルでもない場合には false を返しま
   else
     puts "no match"
   end
-  #=> no match
+  # => no match
   # ただし、警告がでる。warning: regex literal in condition
 
   reg = Regexp.compile("foo")
@@ -269,14 +268,14 @@ string が文字列でもシンボルでもない場合には false を返しま
   else
     puts "no match" 
   end
-  #=> no match 
+  # => no match
 
   if reg
     puts "match" 
   else
     puts "no match"
   end
-  #=> match
+  # => match
   # reg は nil でも false でも無いので常にtrue
 
 
@@ -286,10 +285,10 @@ string が文字列でもシンボルでもない場合には false を返しま
 真を返します。
 
   reg = Regexp.new("foobar", Regexp::IGNORECASE)
-  p reg.casefold? #=> true
+  p reg.casefold? # => true
 
   reg = Regexp.new("hogehoge")
-  p reg.casefold? #=> false
+  p reg.casefold? # => false
 
 --- fixed_encoding? -> bool
 
@@ -353,9 +352,9 @@ pos を指定しても [[m:MatchData#offset]] 等の結果
 マッチした場合はブロックの値を返し、マッチしなかった場合は nil を返します。
 
   results = []
-  /((.)\2)/.match("foo") {|m| results << m[0] } #=> ["oo"] 
-  /((.)\2)/.match("bar") {|m| results << m[0] } #=> nil
-  results #=> ["oo"]
+  /((.)\2)/.match("foo") {|m| results << m[0] } # => ["oo"] 
+  /((.)\2)/.match("bar") {|m| results << m[0] } # => nil
+  results # => ["oo"]
 
 @param str 文字列を指定します。str との正規表現マッチを行います。
 
@@ -366,13 +365,14 @@ pos を指定しても [[m:MatchData#offset]] 等の結果
   reg = Regexp.new("foo")
 
   if reg.match("foobar")
-    print "match\n" #=> match
+    puts "match"
   end
+  # => match
 
-  p reg.match("foobar") #=> #<MatchData:0x29403fc>
-  p reg.match("bar")    #=> nil
+  p reg.match("foobar") # => #<MatchData:0x29403fc>
+  p reg.match("bar")    # => nil
 
-  p /(foo)(bar)(baz)/.match("foobarbaz").to_a.values_at(1,2,3) #=> ["foo", "bar", "baz"]
+  p /(foo)(bar)(baz)/.match("foobarbaz").to_a.values_at(1,2,3) # => ["foo", "bar", "baz"]
 
 === 便利な使いかた
 正規表現にマッチした部分文字列だけが必要な場合に、
@@ -411,10 +411,10 @@ nil.captures を呼び出そうとして例外 [[c:NoMethodError]] が発生し�
 マッチした場合 true を返し、マッチしない場合には false を返します。
 また、[[m:$~]] などパターンマッチに関する組み込み変数の値は変更されません。
 
-  /R.../.match?("Ruby")    #=> true
-  /R.../.match?("Ruby", 1) #=> false
-  /P.../.match?("Ruby")    #=> false
-  $&                       #=> nil
+  /R.../.match?("Ruby")    # => true
+  /R.../.match?("Ruby", 1) # => false
+  /P.../.match?("Ruby")    # => false
+  $&                       # => nil
 
 @see [[m:Regexp#match]]
 #@end
@@ -436,13 +436,13 @@ nil.captures を呼び出そうとして例外 [[c:NoMethodError]] が発生し�
   p Regexp::IGNORECASE # => 1
   p //i.options        # => 1
 
-  p Regexp.new("foo", Regexp::IGNORECASE ).options #=> 1
-  p Regexp.new("foo", Regexp::EXTENDED).options    #=> 2
-  p Regexp.new("foo", Regexp::IGNORECASE | Regexp::EXTENDED).options #=> 3
-  p Regexp.new("foo", Regexp::MULTILINE).options #=> 4
-  p Regexp.new("foo", Regexp::IGNORECASE | Regexp::MULTILINE ).options #=> 5
-  p Regexp.new("foo", Regexp::MULTILINE | Regexp::EXTENDED).options #=>6
-  p Regexp.new("foo", Regexp::IGNORECASE | Regexp::MULTILINE | Regexp::EXTENDED).options #=> 7
+  p Regexp.new("foo", Regexp::IGNORECASE ).options # => 1
+  p Regexp.new("foo", Regexp::EXTENDED).options    # => 2
+  p Regexp.new("foo", Regexp::IGNORECASE | Regexp::EXTENDED).options # => 3
+  p Regexp.new("foo", Regexp::MULTILINE).options # => 4
+  p Regexp.new("foo", Regexp::IGNORECASE | Regexp::MULTILINE ).options # => 5
+  p Regexp.new("foo", Regexp::MULTILINE | Regexp::EXTENDED).options # =>6
+  p Regexp.new("foo", Regexp::IGNORECASE | Regexp::MULTILINE | Regexp::EXTENDED).options # => 7
 
 --- source -> String
 
@@ -482,23 +482,23 @@ otherが同じパターン、オプション、文字コードの正規表現で
 
 @param other 正規表現を指定します。
 
-  p /^eee$/   == /~eee$/x   #=> false
-  p /^eee$/   == /~eee$/i   #=> false
-  p /^eee$/e  == /~eee$/u   #=> false
-  p /^eee$/ == Regexp.new("^eee$") #=> true
-  p /^eee$/.eql?(/^eee$/)          #=> true
+  p /^eee$/   == /~eee$/x   # => false
+  p /^eee$/   == /~eee$/i   # => false
+  p /^eee$/e  == /~eee$/u   # => false
+  p /^eee$/ == Regexp.new("^eee$") # => true
+  p /^eee$/.eql?(/^eee$/)          # => true
 
 --- hash -> Integer
 正規表現のオプションやテキストに基づいたハッシュ値を返します。
 
-  p /abc/i.hash #=> 4893115
-  p /abc/.hash  #=> 4856055
+  p /abc/i.hash # => 4893115
+  p /abc/.hash  # => 4856055
 
 --- inspect -> String
 [[m:Regexp#to_s]] より自然な文字列を返します。
 
-  p /^ugou.*?/i.to_s    #=> "(?i-mx:^ugou.*?)"
-  p /^ugou.*?/i.inspect #=> "/^ugou.*?/i"
+  p /^ugou.*?/i.to_s    # => "(?i-mx:^ugou.*?)"
+  p /^ugou.*?/i.inspect # => "/^ugou.*?/i"
 
 @see [[m:Regexp#to_s]]
 
@@ -518,14 +518,14 @@ Hash のキーは名前付きキャプチャの名前で、値は
 その名前に関連付けられたキャプチャの index のリストを返します。
 
   /(?<foo>.)(?<bar>.)/.named_captures
-  #=> {"foo"=>[1], "bar"=>[2]}
+  # => {"foo"=>[1], "bar"=>[2]}
   
   /(?<foo>.)(?<foo>.)/.named_captures
-  #=> {"foo"=>[1, 2]}
+  # => {"foo"=>[1, 2]}
 
   # 名前付きキャプチャを持たないときは空の Hash を返します。
   /(.)(.)/.named_captures
-  #=> {}
+  # => {}
 
 --- names -> [String]
 正規表現に含まれる名前付きキャプチャ(named capture)の名前を
@@ -533,12 +533,12 @@ Hash のキーは名前付きキャプチャの名前で、値は
 
   /(?<foo>.)(?<bar>.)(?<baz>.)/.names
   
-  #=> ["foo", "bar", "baz"]
+  # => ["foo", "bar", "baz"]
      /(?<foo>.)(?<foo>.)/.names
-  #=> ["foo"]
+  # => ["foo"]
   
   /(.)(.)/.names
-  #=> []
+  # => []
 
 == Constants
 


### PR DESCRIPTION
ドキュメント参照中に気になった部分があったので、修正いたしました。

* 出力が `puts`だと戻り値のクラスがわかりづらい部分を`p`に修正
* `print "hoge\n"`などとなっているコードを`puts "hoge"`に統一
* 出力を表す記号を`# =>`に統一